### PR TITLE
fix(home): add eslint directive to suppress exhaustive-deps warnings

### DIFF
--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -145,6 +145,7 @@ function Home() {
 
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
This pull request makes a minor update to the `Home` component to suppress an ESLint warning about missing dependencies in a React hook by adding an inline comment.