### PR TITLE
feat(frontend): event-driven JWT auth and cold-start loading tip

### DIFF
--- a/frontend/src/components/LoadingOverlay.js
+++ b/frontend/src/components/LoadingOverlay.js
@@ -1,10 +1,52 @@
-import React from 'react';
-import { Box, CircularProgress, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { Box, CircularProgress, Typography, Tooltip, Fade, Stack } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 
-function LoadingOverlay({ loading }) {
+// Render free-tier specs — surface a friendly note when a request hangs long
+// enough that the user might think the app is broken. Numbers come from
+// Render's published free-instance limits (see README "Live API" section).
+const FREE_TIER_INFO = "We're on Render's free tier (0.1 CPU / 512 MB RAM). When the service has been idle, the first request triggers a cold start that usually takes 30–60 seconds. Subsequent requests are fast.";
+
+const LONG_LOAD_MS = 4000;
+const COLD_START_MS = 10000;
+
+function LoadingOverlay({ loading, longLoadMs = LONG_LOAD_MS, coldStartMs = COLD_START_MS }) {
+  const [stage, setStage] = useState('initial');
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!loading) {
+      setStage('initial');
+      setElapsed(0);
+      return;
+    }
+
+    const startedAt = Date.now();
+    const tick = setInterval(() => setElapsed(Math.floor((Date.now() - startedAt) / 1000)), 1000);
+    const longTimer = setTimeout(() => setStage(prev => (prev === 'initial' ? 'slow' : prev)), longLoadMs);
+    const coldTimer = setTimeout(() => setStage('cold'), coldStartMs);
+
+    return () => {
+      clearInterval(tick);
+      clearTimeout(longTimer);
+      clearTimeout(coldTimer);
+    };
+  }, [loading, longLoadMs, coldStartMs]);
+
   if (!loading) return null;
+
+  const message =
+    stage === 'cold'
+      ? 'Still waking up the server…'
+      : stage === 'slow'
+        ? 'Render is taking a while to load up…'
+        : 'Loading data…';
+
   return (
     <Box
+      role="alert"
+      aria-live="polite"
+      aria-busy="true"
       sx={{
         position: 'fixed',
         top: 0,
@@ -19,12 +61,54 @@ function LoadingOverlay({ loading }) {
         flexDirection: 'column',
         gap: 2,
         zIndex: 9999,
+        px: 2,
+        textAlign: 'center',
       }}
     >
       <CircularProgress size={60} />
       <Typography variant="body2" sx={{ color: '#f7f6f2' }}>
-        Loading data…
+        {message}
       </Typography>
+
+      <Fade in={stage !== 'initial'} timeout={400} unmountOnExit>
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{
+            mt: 1,
+            px: 2,
+            py: 1,
+            borderRadius: 2,
+            maxWidth: 460,
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+          }}
+        >
+          <Typography variant="caption" sx={{ color: '#f7f6f2', lineHeight: 1.4 }}>
+            {stage === 'cold'
+              ? `Hang tight — the backend may be cold-starting (${elapsed}s elapsed).`
+              : 'First request after idle can be slow.'}
+          </Typography>
+          <Tooltip
+            arrow
+            enterTouchDelay={0}
+            leaveTouchDelay={6000}
+            title={FREE_TIER_INFO}
+            componentsProps={{
+              tooltip: {
+                sx: { fontSize: 12, maxWidth: 320, lineHeight: 1.5, p: 1.25 },
+              },
+            }}
+          >
+            <InfoOutlinedIcon
+              fontSize="small"
+              aria-label="Why is this slow?"
+              sx={{ color: '#f7f6f2', cursor: 'help', flexShrink: 0 }}
+            />
+          </Tooltip>
+        </Stack>
+      </Fade>
     </Box>
   );
 }

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -27,11 +27,11 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import GroupIcon from '@mui/icons-material/Group';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import LogoutIcon from '@mui/icons-material/Logout';
-import api from '../services/api';
+import { isLoggedIn as checkLoggedIn, getTokenExpiry, logout, onAuthChange } from '../services/auth';
 
 function Navbar({ mode, setMode }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(!!localStorage.getItem('token'));
+  const [isLoggedIn, setIsLoggedIn] = useState(() => checkLoggedIn());
   const navigate = useNavigate();
   const location = useLocation();
   const isMobileNav = useMediaQuery('(max-width:1350px)');
@@ -40,43 +40,31 @@ function Navbar({ mode, setMode }) {
     setMode(prev => (prev === 'light' ? 'dark' : 'light'));
   };
 
+  // Auth state is event-driven: we listen for login/logout in this tab,
+  // storage changes from other tabs, and a single timer that fires exactly
+  // when the JWT's exp claim is reached. No per-navigation network calls,
+  // no polling — the server's 401 response (handled in api.js) is the
+  // source of truth for server-side revocation.
   useEffect(() => {
-    const checkToken = async () => {
-      const token = localStorage.getItem('token');
-      if (!token) {
-        setIsLoggedIn(false);
-        return;
-      }
-      try {
-        const res = await api.post(
-          '/api/auth/verify-token',
-          { token },
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              'Content-Type': 'application/json',
-            },
-          }
-        );
-        if (res.data.valid) {
-          setIsLoggedIn(true);
-        } else {
-          localStorage.removeItem('token');
-          setIsLoggedIn(false);
-          navigate('/login');
-        }
-      } catch (err) {
-        localStorage.removeItem('token');
-        setIsLoggedIn(false);
-        navigate('/login');
-      }
+    const sync = () => setIsLoggedIn(checkLoggedIn());
+
+    const unsubscribe = onAuthChange(sync);
+
+    let expiryTimer;
+    const expiryMs = getTokenExpiry();
+    if (expiryMs) {
+      const delay = Math.max(0, expiryMs - Date.now());
+      expiryTimer = setTimeout(sync, delay + 250);
+    }
+
+    return () => {
+      unsubscribe();
+      if (expiryTimer) clearTimeout(expiryTimer);
     };
-    checkToken();
-  }, [navigate, location]);
+  }, [isLoggedIn]);
 
   const handleLogout = () => {
-    localStorage.removeItem('token');
-    setIsLoggedIn(false);
+    logout();
     navigate('/login');
   };
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getToken, logout } from './auth';
+import { getToken, isTokenExpired, logout } from './auth';
 
 const api = axios.create({
   baseURL: 'https://budget-management-backend-api.onrender.com',
@@ -8,6 +8,16 @@ const api = axios.create({
 api.interceptors.request.use(config => {
   const token = getToken();
   if (token) {
+    // Short-circuit expired tokens client-side so we don't burn a round trip
+    // on a request the server will reject. The 401 interceptor below is the
+    // fallback for tokens revoked server-side (e.g. blacklist).
+    if (isTokenExpired(token)) {
+      logout();
+      if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+      return Promise.reject(new Error('Token expired'));
+    }
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
@@ -18,7 +28,9 @@ api.interceptors.response.use(
   error => {
     if (error.response && error.response.status === 401) {
       logout();
-      window.location.href = '/login';
+      if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
     }
     return Promise.reject(error);
   }

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,5 +1,92 @@
-export const getToken = () => localStorage.getItem('token');
-export const setToken = token => localStorage.setItem('token', token);
-export const removeToken = () => localStorage.removeItem('token');
-export const isLoggedIn = () => !!getToken();
+// Lightweight, polling-free auth state.
+//
+// Tokens are validated on the client by decoding the JWT and inspecting the
+// `exp` claim. The server still does the real check on every protected
+// request (and the api.js 401 interceptor clears the token if the server ever
+// rejects it), so we never need to poll /api/auth/verify-token from the UI.
+//
+// An "auth-change" CustomEvent is dispatched whenever the token mutates, so
+// components subscribe once instead of re-checking on every navigation. The
+// browser `storage` event keeps multiple tabs in sync automatically.
+
+const TOKEN_KEY = 'token';
+const AUTH_EVENT = 'auth-change';
+
+export const getToken = () => localStorage.getItem(TOKEN_KEY);
+
+export const setToken = token => {
+  localStorage.setItem(TOKEN_KEY, token);
+  emitAuthChange();
+};
+
+export const removeToken = () => {
+  localStorage.removeItem(TOKEN_KEY);
+  emitAuthChange();
+};
+
 export const logout = () => removeToken();
+
+// Decode the JWT payload without verifying the signature. The signature is
+// verified server-side; client-side decoding only powers UI decisions like
+// "is the token already expired, don't bother sending the request".
+export const decodeToken = token => {
+  const raw = token ?? getToken();
+  if (!raw || typeof raw !== 'string') return null;
+  const parts = raw.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '==='.slice((base64.length + 3) % 4);
+    const json = typeof atob === 'function' ? atob(padded) : Buffer.from(padded, 'base64').toString('binary');
+    const decoded = decodeURIComponent(
+      json
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+};
+
+export const getTokenExpiry = token => {
+  const payload = decodeToken(token);
+  if (!payload || typeof payload.exp !== 'number') return null;
+  return payload.exp * 1000;
+};
+
+export const isTokenExpired = token => {
+  const expMs = getTokenExpiry(token);
+  if (expMs == null) return false; // no exp claim → treat as non-expiring, let server decide
+  return Date.now() >= expMs;
+};
+
+export const isLoggedIn = () => {
+  const token = getToken();
+  if (!token) return false;
+  return !isTokenExpired(token);
+};
+
+const emitAuthChange = () => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(AUTH_EVENT));
+};
+
+// Subscribe to login/logout transitions. Returns an unsubscribe function.
+// Fires on:
+//   • setToken / removeToken in the current tab (CustomEvent)
+//   • storage mutations from other tabs (storage event)
+export const onAuthChange = handler => {
+  if (typeof window === 'undefined') return () => {};
+  const customHandler = () => handler();
+  const storageHandler = e => {
+    if (e.key === TOKEN_KEY || e.key === null) handler();
+  };
+  window.addEventListener(AUTH_EVENT, customHandler);
+  window.addEventListener('storage', storageHandler);
+  return () => {
+    window.removeEventListener(AUTH_EVENT, customHandler);
+    window.removeEventListener('storage', storageHandler);
+  };
+};


### PR DESCRIPTION
## Summary

- **Kills the JWT polling.** The `Navbar` was POSTing `/api/auth/verify-token` on every route change because `location` was in its `useEffect` deps — one network roundtrip per click. It's now event-driven: client-side JWT decoding for expiry, a custom `auth-change` event for in-tab login/logout, and the `storage` event for cross-tab sync. The 401 interceptor in `api.js` remains the source of truth for server-side revocation (Redis blacklist).
- **Pre-flight expiry check in `api.js`.** Requests with a locally-expired token are short-circuited before they hit the network.
- **Cold-start UX in `LoadingOverlay`.** Messaging escalates as the wait grows:
  - 0–4s: standard "Loading data…"
  - 4s+: a tip badge fades in ("First request after idle can be slow.")
  - 10s+: switches to "Still waking up the server…" with a live elapsed-seconds counter.
  - An `(i)` icon shows a tooltip explaining the Render free-tier specs (0.1 CPU / 512 MB RAM, 30–60s cold start) — numbers sourced from the README's "Live API" note.

## Files changed

- `frontend/src/services/auth.js` — adds `decodeToken`, `getTokenExpiry`, `isTokenExpired`, `onAuthChange`; emits `auth-change` from `setToken`/`removeToken`.
- `frontend/src/services/api.js` — request interceptor short-circuits expired tokens.
- `frontend/src/components/Navbar.js` — subscribes to `onAuthChange` once instead of re-verifying on every navigation; sets a single timer that fires at the JWT `exp`.
- `frontend/src/components/LoadingOverlay.js` — staged messaging + info tooltip.

## Test plan

- [ ] Log in, navigate between `/budgets`, `/expenses`, `/dashboard`, `/profile` — confirm no `/api/auth/verify-token` requests in the Network tab on navigation (was firing every click before).
- [ ] Open the app in two tabs, log out in one — the other tab's Navbar should flip to logged-out state without a refresh (storage event).
- [ ] Manually tamper with `localStorage.token` to an expired JWT, attempt any `api.*` call — request should not be sent; user redirected to `/login`.
- [ ] Hit `/api/users` with a Redis-blacklisted token — 401 interceptor clears the token and bounces to `/login`.
- [ ] Trigger a cold start (idle backend, then any data fetch): verify the overlay shows the "slow" badge around 4s and the "waking up" message at 10s, and that the `(i)` tooltip renders the free-tier note on hover/tap.
- [ ] `LoadingOverlay loading={false}` still renders nothing; existing tests in `App.test.js` (`isLoggedIn`/`setToken`/`logout`) still pass — non-JWT strings yield no `exp` claim and are treated as non-expiring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G9FRsWSKBUa4BADqNyiVMT)_