### PR TITLE
fix(loading-overlay): raise tooltip z-index above backdrop

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,6 @@
-# **Budget Management API - A Comprehensive, Microservices-Based API for Managing Budgets, Expenses, Users, and More! 💰**
+# **Budget Management API** 💰
+
+**_A Comprehensive, Microservices-Based API for Managing Budgets, Expenses, Users, and So Much More!_**
 
 **Welcome to the Budget Management API**, a robust, **microservices** backend platform for managing budgets, expenses, users, orders, and notifications. Built with **Node.js**, **Express**, and **TypeScript**, it supports advanced features like **GraphQL**, **gRPC**, **WebSockets**, and **REST APIs**. 
 

--- a/frontend/src/components/LoadingOverlay.js
+++ b/frontend/src/components/LoadingOverlay.js
@@ -95,7 +95,10 @@ function LoadingOverlay({ loading, longLoadMs = LONG_LOAD_MS, coldStartMs = COLD
             enterTouchDelay={0}
             leaveTouchDelay={6000}
             title={FREE_TIER_INFO}
-            componentsProps={{
+            slotProps={{
+              popper: {
+                sx: { zIndex: 10000 },
+              },
               tooltip: {
                 sx: { fontSize: 12, maxWidth: 320, lineHeight: 1.5, p: 1.25 },
               },


### PR DESCRIPTION
MUI Tooltip's Popper portals to body with z-index 1500, which renders beneath the overlay's 9999 backdrop — the free-tier explainer was appearing behind the blur. Pin the popper's z-index to 10000.