### PR TITLE
feat(routes): bounce logged-in users away from auth pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import Expenses from './pages/Expenses';
 import Users from './pages/Users';
 import Dashboard from './pages/Dashboard';
 import ProtectedRoute from './components/ProtectedRoute';
+import GuestRoute from './components/GuestRoute';
 import ForgotPassword from './pages/ForgotPassword';
 import NotFound from './pages/NotFound';
 import { ThemeProvider, CssBaseline, Box } from '@mui/material';
@@ -43,8 +44,22 @@ function App() {
         <Box component="main" sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
+            <Route
+              path="/login"
+              element={
+                <GuestRoute>
+                  <Login />
+                </GuestRoute>
+              }
+            />
+            <Route
+              path="/register"
+              element={
+                <GuestRoute>
+                  <Register />
+                </GuestRoute>
+              }
+            />
             <Route
               path="/profile"
               element={
@@ -85,7 +100,14 @@ function App() {
                 </ProtectedRoute>
               }
             />
-            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route
+              path="/forgot-password"
+              element={
+                <GuestRoute>
+                  <ForgotPassword />
+                </GuestRoute>
+              }
+            />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </Box>

--- a/frontend/src/components/GuestRoute.js
+++ b/frontend/src/components/GuestRoute.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../services/auth';
+
+function GuestRoute({ children, redirectTo = '/' }) {
+  if (isLoggedIn()) {
+    return <Navigate to={redirectTo} replace />;
+  }
+  return children;
+}
+
+export default GuestRoute;

--- a/frontend/src/components/LoadingOverlay.js
+++ b/frontend/src/components/LoadingOverlay.js
@@ -5,7 +5,8 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 // Render free-tier specs — surface a friendly note when a request hangs long
 // enough that the user might think the app is broken. Numbers come from
 // Render's published free-instance limits (see README "Live API" section).
-const FREE_TIER_INFO = "We're on Render's free tier (0.1 CPU / 512 MB RAM). When the service has been idle, the first request triggers a cold start that usually takes 30–60 seconds. Subsequent requests are fast.";
+const FREE_TIER_INFO =
+  "We're on Render's free tier (0.1 CPU / 512 MB RAM). When the service has been idle, the first request triggers a cold start that usually takes 30–60 seconds. Subsequent requests are fast.";
 
 const LONG_LOAD_MS = 4000;
 const COLD_START_MS = 10000;
@@ -35,12 +36,7 @@ function LoadingOverlay({ loading, longLoadMs = LONG_LOAD_MS, coldStartMs = COLD
 
   if (!loading) return null;
 
-  const message =
-    stage === 'cold'
-      ? 'Still waking up the server…'
-      : stage === 'slow'
-        ? 'Render is taking a while to load up…'
-        : 'Loading data…';
+  const message = stage === 'cold' ? 'Still waking up the server…' : stage === 'slow' ? 'Render is taking a while to load up…' : 'Loading data…';
 
   return (
     <Box
@@ -86,9 +82,7 @@ function LoadingOverlay({ loading, longLoadMs = LONG_LOAD_MS, coldStartMs = COLD
           }}
         >
           <Typography variant="caption" sx={{ color: '#f7f6f2', lineHeight: 1.4 }}>
-            {stage === 'cold'
-              ? `Hang tight — the backend may be cold-starting (${elapsed}s elapsed).`
-              : 'First request after idle can be slow.'}
+            {stage === 'cold' ? `Hang tight — the backend may be cold-starting (${elapsed}s elapsed).` : 'First request after idle can be slow.'}
           </Typography>
           <Tooltip
             arrow
@@ -104,11 +98,7 @@ function LoadingOverlay({ loading, longLoadMs = LONG_LOAD_MS, coldStartMs = COLD
               },
             }}
           >
-            <InfoOutlinedIcon
-              fontSize="small"
-              aria-label="Why is this slow?"
-              sx={{ color: '#f7f6f2', cursor: 'help', flexShrink: 0 }}
-            />
+            <InfoOutlinedIcon fontSize="small" aria-label="Why is this slow?" sx={{ color: '#f7f6f2', cursor: 'help', flexShrink: 0 }} />
           </Tooltip>
         </Stack>
       </Fade>


### PR DESCRIPTION
This pull request introduces a new `GuestRoute` component to ensure that only unauthenticated users can access the login, registration, and forgot password pages. This helps prevent logged-in users from accessing pages meant for guests, improving both security and user experience. The main changes are the creation of the `GuestRoute` component and its integration into the routing logic.

**Authentication and Routing Improvements:**

* Added a new `GuestRoute` component in `frontend/src/components/GuestRoute.js` that redirects authenticated users away from guest-only routes.
* Updated routing in `frontend/src/App.js` to wrap the `/login`, `/register`, and `/forgot-password` routes with `GuestRoute`, ensuring only unauthenticated users can access these pages. [[1]](diffhunk://#diff-4e185b456927ee5c9781afdfbd5054b8cfb34c5b099a169c2bab8c822931625cL46-R62) [[2]](diffhunk://#diff-4e185b456927ee5c9781afdfbd5054b8cfb34c5b099a169c2bab8c822931625cL88-R110)
* Imported the new `GuestRoute` component into `frontend/src/App.js`.