### PR TITLE
feat(passkeys): add WebAuthn passkey auth and management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,18 @@ KAFKA_BROKER=
 # JWT Secret Key
 JWT_SECRET=
 
+# WebAuthn / Passkey Configuration
+# RP_ID: the registrable domain the passkeys are bound to (e.g. example.com).
+#   Leave blank to derive it from the request origin (good for local dev where
+#   the frontend runs on http://localhost:3000 -> rpID "localhost").
+RP_ID=
+# RP_NAME: human-readable relying-party name shown in the OS passkey prompt.
+RP_NAME=
+# WEBAUTHN_ORIGINS: comma-separated allowlist of frontend origins permitted to
+#   perform passkey ceremonies (e.g. https://app.example.com,http://localhost:3000).
+#   Leave blank to trust the request origin (local dev convenience).
+WEBAUTHN_ORIGINS=
+
 # Elasticsearch Configuration
 ELASTIC_SEARCH_URL=
 

--- a/config/webauthn.js
+++ b/config/webauthn.js
@@ -1,0 +1,73 @@
+/**
+ * WebAuthn / passkey relying-party (RP) configuration.
+ *
+ * The RP ID and origin are dictated by where the *browser* runs the ceremony
+ * (the frontend), not by where this API is hosted. To support both local
+ * development (frontend on http://localhost:3000) and production without
+ * hard-coding a single domain, the values are resolved per-request:
+ *
+ *   - If WEBAUTHN_ORIGINS (or RP_ORIGIN) is set, it acts as a strict allowlist
+ *     of acceptable origins. Requests from any other origin are rejected.
+ *   - Otherwise the incoming request's Origin header is trusted (dev-friendly).
+ *
+ * The RP ID is the registrable domain of the resolved origin (or RP_ID when
+ * explicitly configured). Generation and verification both resolve from the
+ * same request, so a single ceremony is always internally consistent.
+ */
+
+const DEFAULT_ORIGINS = ['http://localhost:3000'];
+
+const RP_NAME = process.env.RP_NAME || 'Budget Management System';
+
+const parseList = value =>
+  (value || '')
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+
+const getAllowedOrigins = () => parseList(process.env.WEBAUTHN_ORIGINS || process.env.RP_ORIGIN);
+
+const hostnameOf = origin => {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Resolve the RP context for a request.
+ * @param {import('express').Request} req
+ * @returns {{ rpName: string, rpID: string, origin: string, allowed: boolean }}
+ */
+const resolveRp = req => {
+  const allowlist = getAllowedOrigins();
+  const requestOrigin = (req.get && req.get('origin')) || (req.headers && req.headers.origin) || null;
+
+  let origin;
+  let allowed = true;
+
+  if (allowlist.length > 0) {
+    if (requestOrigin && allowlist.includes(requestOrigin)) {
+      origin = requestOrigin;
+    } else {
+      // Origin not on the allowlist — flag it so the controller can reject.
+      // A missing Origin header (non-browser tooling) is tolerated.
+      origin = allowlist[0];
+      allowed = !requestOrigin;
+    }
+  } else {
+    origin = requestOrigin || DEFAULT_ORIGINS[0];
+  }
+
+  const rpID = process.env.RP_ID || hostnameOf(origin) || 'localhost';
+
+  return { rpName: RP_NAME, rpID, origin, allowed };
+};
+
+module.exports = {
+  resolveRp,
+  getAllowedOrigins,
+  hostnameOf,
+  RP_NAME,
+};

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -49,6 +49,10 @@ const { JWT_SECRET } = process.env;
  *                 message:
  *                   type: string
  *                   example: User registered successfully
+ *                 token:
+ *                   type: string
+ *                   description: JWT for the newly created session (auto-login).
+ *                   example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  *       400:
  *         description: Email already in use.
  *         content:
@@ -74,7 +78,10 @@ exports.register = async (req, res, next) => {
     const user = new User({ username, email, password });
     await user.save();
 
-    res.status(201).json({ message: 'User registered successfully' });
+    // Auto-login so the client can immediately offer passkey enrolment.
+    const token = generateToken(user._id);
+
+    res.status(201).json({ message: 'User registered successfully', token });
   } catch (error) {
     next(error);
   }

--- a/controllers/passkeyController.js
+++ b/controllers/passkeyController.js
@@ -1,0 +1,424 @@
+const crypto = require('crypto');
+const {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} = require('@simplewebauthn/server');
+
+const Passkey = require('../models/passkey');
+const User = require('../models/user');
+const redisClient = require('../services/redisService');
+const { generateToken } = require('../services/jwtService');
+const { resolveRp } = require('../config/webauthn');
+const { defaultPasskeyName } = require('../services/passkeyMetadata');
+
+/**
+ * @swagger
+ * tags:
+ *   name: Passkeys
+ *   description: WebAuthn passkey registration, authentication and management
+ */
+
+const CHALLENGE_TTL_SECONDS = 300; // 5 minutes — generous for the OS prompt.
+const MAX_NAME_LENGTH = 60;
+
+const regChallengeKey = userId => `webauthn:reg:${userId}`;
+const authChallengeKey = flowId => `webauthn:auth:${flowId}`;
+
+const sanitizeName = value => {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, MAX_NAME_LENGTH);
+};
+
+// Reject browser requests whose Origin is not on the configured allowlist.
+const ensureAllowedOrigin = (rp, res) => {
+  if (!rp.allowed) {
+    res.status(403).json({ error: 'Origin not allowed for passkey operations' });
+    return false;
+  }
+  return true;
+};
+
+/**
+ * @swagger
+ * /api/passkeys/register/options:
+ *   post:
+ *     summary: Begin passkey registration for the authenticated user
+ *     tags: [Passkeys]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: PublicKeyCredentialCreationOptions to pass to the browser.
+ *       401:
+ *         description: Authentication required.
+ */
+exports.getRegistrationOptions = async (req, res, next) => {
+  try {
+    const rp = resolveRp(req);
+    if (!ensureAllowedOrigin(rp, res)) return;
+
+    const userId = req.user.userId;
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const existing = await Passkey.find({ user: userId });
+
+    const options = await generateRegistrationOptions({
+      rpName: rp.rpName,
+      rpID: rp.rpID,
+      userName: user.email,
+      userID: new TextEncoder().encode(user._id.toString()),
+      userDisplayName: user.username || user.email,
+      attestationType: 'none',
+      excludeCredentials: existing.map(cred => ({
+        id: cred.credentialID,
+        transports: cred.transports,
+      })),
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'preferred',
+      },
+    });
+
+    await redisClient.set(regChallengeKey(userId), options.challenge, { EX: CHALLENGE_TTL_SECONDS });
+
+    res.status(200).json(options);
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys/register/verify:
+ *   post:
+ *     summary: Complete passkey registration and store the credential
+ *     tags: [Passkeys]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [response]
+ *             properties:
+ *               response:
+ *                 type: object
+ *                 description: The RegistrationResponseJSON produced by the browser.
+ *               name:
+ *                 type: string
+ *                 description: Optional friendly name for the passkey.
+ *     responses:
+ *       201:
+ *         description: Passkey registered successfully.
+ *       400:
+ *         description: Verification failed or challenge expired.
+ */
+exports.verifyRegistration = async (req, res, next) => {
+  try {
+    const rp = resolveRp(req);
+    if (!ensureAllowedOrigin(rp, res)) return;
+
+    const userId = req.user.userId;
+    const { response, name } = req.body;
+    if (!response) {
+      return res.status(400).json({ error: 'Missing registration response' });
+    }
+
+    const challengeKey = regChallengeKey(userId);
+    const expectedChallenge = await redisClient.get(challengeKey);
+    if (!expectedChallenge) {
+      return res.status(400).json({ error: 'Registration challenge expired. Please try again.' });
+    }
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge,
+        expectedOrigin: rp.origin,
+        expectedRPID: rp.rpID,
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      await redisClient.del(challengeKey);
+      return res.status(400).json({ error: 'Passkey verification failed', details: err.message });
+    }
+
+    await redisClient.del(challengeKey);
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return res.status(400).json({ error: 'Passkey verification failed' });
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp, aaguid } = verification.registrationInfo;
+
+    const existing = await Passkey.findOne({ credentialID: credential.id });
+    if (existing) {
+      return res.status(409).json({ error: 'This passkey is already registered' });
+    }
+
+    const transports = credential.transports || [];
+    const finalName = sanitizeName(name) || defaultPasskeyName({ aaguid, transports, deviceType: credentialDeviceType });
+
+    let passkey;
+    try {
+      passkey = await Passkey.create({
+        user: userId,
+        credentialID: credential.id,
+        publicKey: Buffer.from(credential.publicKey),
+        counter: credential.counter || 0,
+        transports,
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+        aaguid: aaguid || '',
+        name: finalName,
+        lastUsedAt: new Date(),
+      });
+    } catch (err) {
+      if (err.code === 11000) {
+        return res.status(409).json({ error: 'This passkey is already registered' });
+      }
+      throw err;
+    }
+
+    res.status(201).json({ message: 'Passkey registered successfully', passkey: passkey.toClientJSON() });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys/login/options:
+ *   post:
+ *     summary: Begin passwordless passkey authentication
+ *     tags: [Passkeys]
+ *     responses:
+ *       200:
+ *         description: Authentication options and a one-time flow identifier.
+ */
+exports.getLoginOptions = async (req, res, next) => {
+  try {
+    const rp = resolveRp(req);
+    if (!ensureAllowedOrigin(rp, res)) return;
+
+    // Usernameless / discoverable-credential flow: no allowCredentials so the
+    // browser offers any passkey registered for this RP.
+    const options = await generateAuthenticationOptions({
+      rpID: rp.rpID,
+      userVerification: 'preferred',
+    });
+
+    const flowId = crypto.randomUUID();
+    await redisClient.set(authChallengeKey(flowId), options.challenge, { EX: CHALLENGE_TTL_SECONDS });
+
+    res.status(200).json({ flowId, options });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys/login/verify:
+ *   post:
+ *     summary: Complete passkey authentication and issue a JWT
+ *     tags: [Passkeys]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [flowId, response]
+ *             properties:
+ *               flowId:
+ *                 type: string
+ *               response:
+ *                 type: object
+ *                 description: The AuthenticationResponseJSON produced by the browser.
+ *     responses:
+ *       200:
+ *         description: Login successful, returns a JWT.
+ *       401:
+ *         description: Passkey not recognized or verification failed.
+ */
+exports.verifyLogin = async (req, res, next) => {
+  try {
+    const rp = resolveRp(req);
+    if (!ensureAllowedOrigin(rp, res)) return;
+
+    const { flowId, response } = req.body;
+    if (!flowId || !response) {
+      return res.status(400).json({ error: 'Missing flowId or response' });
+    }
+
+    const challengeKey = authChallengeKey(flowId);
+    const expectedChallenge = await redisClient.get(challengeKey);
+    if (!expectedChallenge) {
+      return res.status(400).json({ error: 'Authentication challenge expired. Please try again.' });
+    }
+
+    const passkey = await Passkey.findOne({ credentialID: response.id });
+    if (!passkey) {
+      await redisClient.del(challengeKey);
+      return res.status(401).json({ error: 'Passkey not recognized' });
+    }
+
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge,
+        expectedOrigin: rp.origin,
+        expectedRPID: rp.rpID,
+        credential: {
+          id: passkey.credentialID,
+          publicKey: new Uint8Array(passkey.publicKey),
+          counter: passkey.counter,
+          transports: passkey.transports,
+        },
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      await redisClient.del(challengeKey);
+      return res.status(401).json({ error: 'Passkey verification failed', details: err.message });
+    }
+
+    await redisClient.del(challengeKey);
+
+    if (!verification.verified) {
+      return res.status(401).json({ error: 'Passkey verification failed' });
+    }
+
+    // Persist the rolling signature counter and last-used timestamp.
+    passkey.counter = verification.authenticationInfo.newCounter;
+    passkey.lastUsedAt = new Date();
+    await passkey.save();
+
+    const user = await User.findById(passkey.user);
+    if (!user) {
+      return res.status(401).json({ error: 'Account no longer exists' });
+    }
+
+    const token = generateToken(user._id);
+    res.status(200).json({ message: 'Login successful', token });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys:
+ *   get:
+ *     summary: List the authenticated user's passkeys
+ *     tags: [Passkeys]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: An array of the user's passkeys (without credential material).
+ */
+exports.listPasskeys = async (req, res, next) => {
+  try {
+    const passkeys = await Passkey.find({ user: req.user.userId }).sort({ createdAt: -1 });
+    res.status(200).json(passkeys.map(p => p.toClientJSON()));
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys/{id}:
+ *   patch:
+ *     summary: Rename one of the authenticated user's passkeys
+ *     tags: [Passkeys]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Updated passkey.
+ *       404:
+ *         description: Passkey not found.
+ */
+exports.renamePasskey = async (req, res, next) => {
+  try {
+    const name = sanitizeName(req.body.name);
+    if (!name) {
+      return res.status(400).json({ error: 'A non-empty name is required' });
+    }
+
+    const passkey = await Passkey.findOneAndUpdate({ _id: req.params.id, user: req.user.userId }, { name }, { new: true, runValidators: true });
+
+    if (!passkey) {
+      return res.status(404).json({ error: 'Passkey not found' });
+    }
+
+    res.status(200).json(passkey.toClientJSON());
+  } catch (error) {
+    if (error.name === 'CastError') {
+      return res.status(400).json({ error: 'Invalid passkey ID' });
+    }
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /api/passkeys/{id}:
+ *   delete:
+ *     summary: Delete one of the authenticated user's passkeys
+ *     tags: [Passkeys]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Passkey deleted.
+ *       404:
+ *         description: Passkey not found.
+ */
+exports.deletePasskey = async (req, res, next) => {
+  try {
+    const passkey = await Passkey.findOneAndDelete({ _id: req.params.id, user: req.user.userId });
+    if (!passkey) {
+      return res.status(404).json({ error: 'Passkey not found' });
+    }
+    res.status(200).json({ message: 'Passkey deleted' });
+  } catch (error) {
+    if (error.name === 'CastError') {
+      return res.status(400).json({ error: 'Invalid passkey ID' });
+    }
+    next(error);
+  }
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.2.1",
         "@mui/material": "^6.2.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "axios": "^1.7.9",
         "chart.js": "^4.4.7",
         "cra-template": "1.2.0",
@@ -3740,6 +3741,12 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.37",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.2.1",
     "@mui/material": "^6.2.1",
+    "@simplewebauthn/browser": "^13.3.0",
     "axios": "^1.7.9",
     "chart.js": "^4.4.7",
     "cra-template": "1.2.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import Budgets from './pages/Budgets';
 import Expenses from './pages/Expenses';
 import Users from './pages/Users';
 import Dashboard from './pages/Dashboard';
+import Passkeys from './pages/Passkeys';
 import ProtectedRoute from './components/ProtectedRoute';
 import GuestRoute from './components/GuestRoute';
 import ForgotPassword from './pages/ForgotPassword';
@@ -97,6 +98,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <Dashboard />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/passkeys"
+              element={
+                <ProtectedRoute>
+                  <Passkeys />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -10,6 +10,9 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Menu,
+  MenuItem,
+  Divider,
   Box,
   Stack,
   useMediaQuery,
@@ -27,14 +30,20 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import GroupIcon from '@mui/icons-material/Group';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import LogoutIcon from '@mui/icons-material/Logout';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { isLoggedIn as checkLoggedIn, getTokenExpiry, logout, onAuthChange } from '../services/auth';
 
 function Navbar({ mode, setMode }) {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(() => checkLoggedIn());
+  const [accountAnchor, setAccountAnchor] = useState(null);
   const navigate = useNavigate();
   const location = useLocation();
   const isMobileNav = useMediaQuery('(max-width:1350px)');
+
+  const openAccountMenu = e => setAccountAnchor(e.currentTarget);
+  const closeAccountMenu = () => setAccountAnchor(null);
 
   const handleToggleMode = () => {
     setMode(prev => (prev === 'light' ? 'dark' : 'light'));
@@ -64,8 +73,14 @@ function Navbar({ mode, setMode }) {
   }, [isLoggedIn]);
 
   const handleLogout = () => {
+    closeAccountMenu();
     logout();
     navigate('/login');
+  };
+
+  const goToPasskeys = () => {
+    closeAccountMenu();
+    navigate('/passkeys');
   };
 
   const baseNavLinks = [
@@ -77,13 +92,15 @@ function Navbar({ mode, setMode }) {
     { to: '/users', label: 'Users', icon: <GroupIcon /> },
   ];
 
+  // When signed in, account actions (Passkeys, Log Out) live in a dropdown
+  // instead of as flat nav buttons; guests get Login/Register instead.
   let navLinks = [...baseNavLinks];
-  if (isLoggedIn) {
-    navLinks.push({ to: '#', label: 'Logout', icon: <LogoutIcon />, action: handleLogout });
-  } else {
+  if (!isLoggedIn) {
     navLinks.push({ to: '/login', label: 'Login', icon: <LoginIcon /> });
     navLinks.push({ to: '/register', label: 'Register', icon: <PersonAddIcon /> });
   }
+
+  const accountActive = location.pathname === '/passkeys';
 
   return (
     <>
@@ -125,35 +142,68 @@ function Navbar({ mode, setMode }) {
             </Box>
           </Stack>
 
-          <Box sx={{ display: isMobileNav ? 'none' : 'flex', gap: 1 }}>
+          <Box sx={{ display: isMobileNav ? 'none' : 'flex', gap: 1, alignItems: 'center' }}>
             {navLinks.map(link => {
               const isActive = location.pathname === link.to;
-              const isLogout = link.label === 'Logout';
               const buttonStyle = {
                 px: 2,
                 borderRadius: 999,
                 bgcolor: isActive ? 'rgba(31, 122, 99, 0.14)' : 'transparent',
-                color: isLogout ? 'error.main' : 'text.primary',
+                color: 'text.primary',
                 border: isActive ? '1px solid rgba(31, 122, 99, 0.3)' : '1px solid transparent',
-                '&:hover': {
-                  bgcolor: isLogout ? 'rgba(216, 74, 74, 0.1)' : 'rgba(31, 122, 99, 0.12)',
-                },
+                '&:hover': { bgcolor: 'rgba(31, 122, 99, 0.12)' },
               };
-
-              if (link.action) {
-                return (
-                  <Button key={link.label} color="inherit" startIcon={link.icon} onClick={link.action} sx={buttonStyle}>
-                    {link.label}
-                  </Button>
-                );
-              }
               return (
                 <Button key={link.to} component={Link} to={link.to} color="inherit" startIcon={link.icon} sx={buttonStyle}>
                   {link.label}
                 </Button>
               );
             })}
+
+            {isLoggedIn && (
+              <Button
+                color="inherit"
+                onClick={openAccountMenu}
+                startIcon={<AccountCircleIcon />}
+                endIcon={<KeyboardArrowDownIcon />}
+                aria-haspopup="true"
+                aria-expanded={Boolean(accountAnchor)}
+                sx={{
+                  px: 2,
+                  borderRadius: 999,
+                  color: 'text.primary',
+                  bgcolor: accountActive || accountAnchor ? 'rgba(31, 122, 99, 0.14)' : 'transparent',
+                  border: accountActive || accountAnchor ? '1px solid rgba(31, 122, 99, 0.3)' : '1px solid transparent',
+                  '&:hover': { bgcolor: 'rgba(31, 122, 99, 0.12)' },
+                }}
+              >
+                Account
+              </Button>
+            )}
           </Box>
+
+          <Menu
+            anchorEl={accountAnchor}
+            open={Boolean(accountAnchor)}
+            onClose={closeAccountMenu}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            slotProps={{ paper: { sx: { mt: 1, minWidth: 200, borderRadius: 2, overflow: 'visible' } } }}
+          >
+            <MenuItem onClick={goToPasskeys} selected={accountActive} sx={{ py: 1.25 }}>
+              <ListItemIcon sx={{ color: 'primary.main' }}>
+                <FingerprintIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Passkeys" />
+            </MenuItem>
+            <Divider sx={{ my: 0.5 }} />
+            <MenuItem onClick={handleLogout} sx={{ py: 1.25, color: 'error.main' }}>
+              <ListItemIcon sx={{ color: 'inherit' }}>
+                <LogoutIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Log Out" />
+            </MenuItem>
+          </Menu>
 
           <IconButton color="inherit" onClick={handleToggleMode} sx={{ ml: 1 }}>
             {mode === 'light' ? <DarkModeIcon /> : <LightModeIcon />}
@@ -168,36 +218,58 @@ function Navbar({ mode, setMode }) {
           <List sx={{ width: '100%' }}>
             {navLinks.map(link => {
               const isActive = location.pathname === link.to;
-              const isLogout = link.label === 'Logout';
-              const listItemStyles = {
-                borderRadius: 2,
-                mb: 0.5,
-                bgcolor: isActive ? 'rgba(31, 122, 99, 0.14)' : 'transparent',
-                color: isLogout ? 'error.main' : 'text.primary',
-              };
-
-              if (link.action) {
-                return (
-                  <ListItemButton
-                    key={link.label}
-                    onClick={() => {
-                      setDrawerOpen(false);
-                      link.action();
-                    }}
-                    sx={listItemStyles}
-                  >
-                    <ListItemIcon sx={{ color: 'inherit' }}>{link.icon}</ListItemIcon>
-                    <ListItemText primary={link.label} />
-                  </ListItemButton>
-                );
-              }
               return (
-                <ListItemButton key={link.to} component={Link} to={link.to} onClick={() => setDrawerOpen(false)} sx={listItemStyles}>
+                <ListItemButton
+                  key={link.to}
+                  component={Link}
+                  to={link.to}
+                  onClick={() => setDrawerOpen(false)}
+                  sx={{
+                    borderRadius: 2,
+                    mb: 0.5,
+                    bgcolor: isActive ? 'rgba(31, 122, 99, 0.14)' : 'transparent',
+                    color: 'text.primary',
+                  }}
+                >
                   <ListItemIcon sx={{ color: 'inherit' }}>{link.icon}</ListItemIcon>
                   <ListItemText primary={link.label} />
                 </ListItemButton>
               );
             })}
+
+            {isLoggedIn && (
+              <>
+                <Divider sx={{ my: 1 }} />
+                <ListItemButton
+                  component={Link}
+                  to="/passkeys"
+                  onClick={() => setDrawerOpen(false)}
+                  sx={{
+                    borderRadius: 2,
+                    mb: 0.5,
+                    bgcolor: accountActive ? 'rgba(31, 122, 99, 0.14)' : 'transparent',
+                    color: 'text.primary',
+                  }}
+                >
+                  <ListItemIcon sx={{ color: 'inherit' }}>
+                    <FingerprintIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Passkeys" />
+                </ListItemButton>
+                <ListItemButton
+                  onClick={() => {
+                    setDrawerOpen(false);
+                    handleLogout();
+                  }}
+                  sx={{ borderRadius: 2, mb: 0.5, color: 'error.main' }}
+                >
+                  <ListItemIcon sx={{ color: 'inherit' }}>
+                    <LogoutIcon />
+                  </ListItemIcon>
+                  <ListItemText primary="Log Out" />
+                </ListItemButton>
+              </>
+            )}
           </List>
         </Box>
       </Drawer>

--- a/frontend/src/components/PasskeyPromptModal.js
+++ b/frontend/src/components/PasskeyPromptModal.js
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { Dialog, Box, Typography, Button, Stack, Alert, CircularProgress, Fade } from '@mui/material';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import BoltIcon from '@mui/icons-material/Bolt';
+import ShieldIcon from '@mui/icons-material/Shield';
+import PhonelinkLockIcon from '@mui/icons-material/PhonelinkLock';
+import { registerPasskey, describePasskeyError } from '../services/passkeys';
+
+const benefits = [
+  { icon: <BoltIcon fontSize="small" />, text: 'Sign in instantly — no password to type' },
+  { icon: <ShieldIcon fontSize="small" />, text: 'Phishing-resistant and unique to this site' },
+  { icon: <PhonelinkLockIcon fontSize="small" />, text: 'Unlocked by your face, fingerprint or device PIN' },
+];
+
+/**
+ * Friendly modal shown right after sign-up (and re-usable elsewhere) inviting
+ * the user to enrol a passkey. Runs the registration ceremony in place and
+ * reports success/failure without ever falling back to a browser alert.
+ */
+function PasskeyPromptModal({
+  open,
+  onClose,
+  onCreated,
+  title = 'Set up a passkey?',
+  subtitle = 'Add a passkey for faster, password-free sign-in next time.',
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+
+  const reset = () => {
+    setLoading(false);
+    setError('');
+    setDone(false);
+  };
+
+  const handleClose = (created = false) => {
+    if (loading) return;
+    reset();
+    onClose?.(created);
+  };
+
+  const handleCreate = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      const passkey = await registerPasskey();
+      setDone(true);
+      onCreated?.(passkey);
+      setTimeout(() => handleClose(true), 1100);
+    } catch (err) {
+      const { cancelled, message } = describePasskeyError(err);
+      setError(cancelled ? 'No passkey was created. You can add one anytime from the Account menu.' : message);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={() => handleClose(false)} maxWidth="xs" fullWidth slotProps={{ paper: { sx: { borderRadius: 4, overflow: 'hidden' } } }}>
+      <Box
+        sx={{
+          px: 3,
+          pt: 4,
+          pb: 3,
+          textAlign: 'center',
+          background: 'linear-gradient(135deg, rgba(31, 122, 99, 0.16), rgba(242, 179, 90, 0.18))',
+        }}
+      >
+        <Box
+          sx={{
+            width: 76,
+            height: 76,
+            borderRadius: '50%',
+            mx: 'auto',
+            mb: 2,
+            display: 'grid',
+            placeItems: 'center',
+            color: 'primary.contrastText',
+            background: 'linear-gradient(135deg, #1f7a63, #2aa88a)',
+            boxShadow: '0 12px 26px rgba(25, 90, 72, 0.4)',
+          }}
+        >
+          {done ? <CheckCircleIcon sx={{ fontSize: 40 }} /> : <FingerprintIcon sx={{ fontSize: 40 }} />}
+        </Box>
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          {done ? 'Passkey created' : title}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {done ? "You're all set — use it to sign in next time." : subtitle}
+        </Typography>
+      </Box>
+
+      <Box sx={{ p: 3 }}>
+        <Fade in={!done} unmountOnExit>
+          <Stack spacing={1.5} sx={{ mb: error ? 2 : 3 }}>
+            {benefits.map(b => (
+              <Stack key={b.text} direction="row" spacing={1.5} alignItems="center">
+                <Box sx={{ color: 'primary.main', display: 'grid', placeItems: 'center' }}>{b.icon}</Box>
+                <Typography variant="body2">{b.text}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        </Fade>
+
+        {error && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {!done && (
+          <Stack spacing={1.25}>
+            <Button
+              variant="contained"
+              size="large"
+              fullWidth
+              onClick={handleCreate}
+              disabled={loading}
+              startIcon={loading ? <CircularProgress size={18} color="inherit" /> : <FingerprintIcon />}
+            >
+              {loading ? 'Waiting for your device…' : 'Create a passkey'}
+            </Button>
+            <Button variant="text" fullWidth onClick={() => handleClose(false)} disabled={loading} sx={{ color: 'text.secondary' }}>
+              Maybe later
+            </Button>
+          </Stack>
+        )}
+      </Box>
+    </Dialog>
+  );
+}
+
+export default PasskeyPromptModal;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,16 +1,20 @@
 import React, { useState } from 'react';
 import { Container, TextField, Button, Typography, Paper, Box, Grid, Divider } from '@mui/material';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
 import api from '../services/api';
 import { setToken } from '../services/auth';
 import { useNavigate, Link } from 'react-router-dom';
 import LoadingOverlay from '../components/LoadingOverlay';
+import { authenticateWithPasskey, isPasskeySupported, describePasskeyError } from '../services/passkeys';
 
 function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
   const navigate = useNavigate();
+  const passkeySupported = isPasskeySupported();
 
   const handleLogin = async () => {
     setLoading(true);
@@ -23,6 +27,21 @@ function Login() {
       setError('Invalid email or password, or an error has occurred.');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handlePasskeyLogin = async () => {
+    setError(null);
+    setPasskeyLoading(true);
+    try {
+      const token = await authenticateWithPasskey();
+      setToken(token);
+      navigate('/budgets');
+    } catch (err) {
+      const { cancelled, message } = describePasskeyError(err);
+      if (!cancelled) setError(message);
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -64,6 +83,16 @@ function Login() {
               <Button variant="contained" fullWidth onClick={handleLogin} size="large">
                 Login
               </Button>
+
+              {passkeySupported && (
+                <>
+                  <Divider sx={{ my: 2.5 }}>or</Divider>
+                  <Button variant="outlined" fullWidth size="large" startIcon={<FingerprintIcon />} onClick={handlePasskeyLogin} disabled={passkeyLoading}>
+                    {passkeyLoading ? 'Waiting for your device…' : 'Sign in with a passkey'}
+                  </Button>
+                </>
+              )}
+
               <Divider sx={{ my: 3 }} />
               <Typography variant="body2" sx={{ textAlign: 'center', mb: 1 }}>
                 Don&apos;t have an account?{' '}

--- a/frontend/src/pages/Passkeys.js
+++ b/frontend/src/pages/Passkeys.js
@@ -1,0 +1,380 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Container,
+  Grid,
+  Paper,
+  Typography,
+  Button,
+  Stack,
+  Chip,
+  IconButton,
+  Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Tooltip,
+  Alert,
+  Snackbar,
+  CircularProgress,
+} from '@mui/material';
+import FingerprintIcon from '@mui/icons-material/Fingerprint';
+import AddIcon from '@mui/icons-material/AddCircleOutline';
+import EditIcon from '@mui/icons-material/EditOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutline';
+import KeyIcon from '@mui/icons-material/VpnKey';
+import LaptopIcon from '@mui/icons-material/Laptop';
+import SmartphoneIcon from '@mui/icons-material/Smartphone';
+import UsbIcon from '@mui/icons-material/Usb';
+import CloudDoneIcon from '@mui/icons-material/CloudDone';
+import ShieldIcon from '@mui/icons-material/Shield';
+import BoltIcon from '@mui/icons-material/Bolt';
+import PhonelinkLockIcon from '@mui/icons-material/PhonelinkLock';
+import LoadingOverlay from '../components/LoadingOverlay';
+import {
+  isPasskeySupported,
+  isPlatformAuthenticatorAvailable,
+  registerPasskey,
+  listPasskeys,
+  renamePasskey,
+  deletePasskey,
+  describePasskeyError,
+} from '../services/passkeys';
+
+const transportIcon = (transports = []) => {
+  const t = new Set(transports);
+  if (t.has('internal')) return <LaptopIcon />;
+  if (t.has('hybrid')) return <SmartphoneIcon />;
+  if (t.has('usb') || t.has('nfc') || t.has('ble')) return <UsbIcon />;
+  return <KeyIcon />;
+};
+
+const formatDate = value => {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch {
+    return '—';
+  }
+};
+
+const formatLastUsed = value => {
+  if (!value) return 'Never used';
+  const then = new Date(value).getTime();
+  if (Number.isNaN(then)) return 'Never used';
+  const diff = Date.now() - then;
+  const minutes = Math.round(diff / 60000);
+  if (minutes < 1) return 'Used just now';
+  if (minutes < 60) return `Used ${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `Used ${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `Used ${days} day${days === 1 ? '' : 's'} ago`;
+  return `Last used ${formatDate(value)}`;
+};
+
+function Passkeys() {
+  const [passkeys, setPasskeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [platformAvailable, setPlatformAvailable] = useState(true);
+  const supported = isPasskeySupported();
+
+  const [renameTarget, setRenameTarget] = useState(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [renaming, setRenaming] = useState(false);
+
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const [snack, setSnack] = useState({ open: false, message: '', severity: 'success' });
+  const showSnack = (message, severity = 'success') => setSnack({ open: true, message, severity });
+  const closeSnack = () => setSnack(prev => ({ ...prev, open: false }));
+
+  const fetchList = useCallback(async () => {
+    try {
+      const data = await listPasskeys();
+      setPasskeys(data);
+    } catch (err) {
+      showSnack(err?.response?.data?.error || 'Could not load your passkeys.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchList();
+    if (supported) {
+      isPlatformAuthenticatorAvailable().then(setPlatformAvailable);
+    }
+  }, [fetchList, supported]);
+
+  const handleAdd = async () => {
+    setAdding(true);
+    try {
+      const passkey = await registerPasskey();
+      await fetchList();
+      showSnack(`Passkey added${passkey?.name ? ` — “${passkey.name}”. Rename it anytime below.` : '.'}`, 'success');
+    } catch (err) {
+      const { cancelled, message } = describePasskeyError(err);
+      if (!cancelled) showSnack(message, 'error');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const openRename = passkey => {
+    setRenameTarget(passkey);
+    setRenameValue(passkey.name || '');
+  };
+
+  const submitRename = async () => {
+    const name = renameValue.trim();
+    if (!name || !renameTarget) return;
+    setRenaming(true);
+    try {
+      const updated = await renamePasskey(renameTarget.id, name);
+      setPasskeys(prev => prev.map(p => (p.id === updated.id ? updated : p)));
+      setRenameTarget(null);
+      showSnack('Passkey renamed.', 'success');
+    } catch (err) {
+      showSnack(err?.response?.data?.error || 'Could not rename the passkey.', 'error');
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await deletePasskey(deleteTarget.id);
+      setPasskeys(prev => prev.filter(p => p.id !== deleteTarget.id));
+      setDeleteTarget(null);
+      showSnack('Passkey removed.', 'success');
+    } catch (err) {
+      showSnack(err?.response?.data?.error || 'Could not delete the passkey.', 'error');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) return <LoadingOverlay loading />;
+
+  return (
+    <Box sx={{ py: { xs: 4, md: 7 } }}>
+      <Container>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          justifyContent="space-between"
+          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          spacing={2}
+          sx={{ mb: 4 }}
+        >
+          <Box>
+            <Typography variant="h4" sx={{ fontWeight: 700 }}>
+              Passkeys
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, maxWidth: 560 }}>
+              Passkeys let you sign in with your fingerprint, face, or device PIN — no password required. Add one per device for the smoothest, most secure
+              access.
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            size="large"
+            startIcon={adding ? <CircularProgress size={18} color="inherit" /> : <AddIcon />}
+            onClick={handleAdd}
+            disabled={!supported || adding}
+            sx={{ flexShrink: 0 }}
+          >
+            {adding ? 'Waiting for device…' : 'Add a passkey'}
+          </Button>
+        </Stack>
+
+        {!supported && (
+          <Alert severity="warning" sx={{ mb: 3 }}>
+            This browser doesn&apos;t support passkeys. Try a recent version of Chrome, Safari, Edge, or Firefox on a device with a screen lock.
+          </Alert>
+        )}
+        {supported && !platformAvailable && (
+          <Alert severity="info" sx={{ mb: 3 }}>
+            No built-in authenticator detected on this device. You can still register a security key or use a nearby phone.
+          </Alert>
+        )}
+
+        <Grid container spacing={4}>
+          <Grid item xs={12} md={8}>
+            {passkeys.length === 0 ? (
+              <Paper sx={{ p: { xs: 4, md: 6 }, textAlign: 'center' }}>
+                <Box
+                  sx={{
+                    width: 84,
+                    height: 84,
+                    borderRadius: '50%',
+                    mx: 'auto',
+                    mb: 2,
+                    display: 'grid',
+                    placeItems: 'center',
+                    color: 'primary.main',
+                    bgcolor: 'rgba(31, 122, 99, 0.12)',
+                  }}
+                >
+                  <FingerprintIcon sx={{ fontSize: 44 }} />
+                </Box>
+                <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
+                  No passkeys yet
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 420, mx: 'auto' }}>
+                  Add your first passkey to enable one-tap, password-free sign-in on this device.
+                </Typography>
+                <Button variant="contained" startIcon={<AddIcon />} onClick={handleAdd} disabled={!supported || adding}>
+                  {adding ? 'Waiting for device…' : 'Add your first passkey'}
+                </Button>
+              </Paper>
+            ) : (
+              <Stack spacing={2}>
+                {passkeys.map(passkey => (
+                  <Paper key={passkey.id} sx={{ p: { xs: 2, sm: 2.5 } }}>
+                    <Stack direction="row" spacing={2} alignItems="center">
+                      <Box
+                        sx={{
+                          width: 52,
+                          height: 52,
+                          borderRadius: 2.5,
+                          flexShrink: 0,
+                          display: 'grid',
+                          placeItems: 'center',
+                          color: 'primary.main',
+                          bgcolor: 'rgba(31, 122, 99, 0.12)',
+                        }}
+                      >
+                        {transportIcon(passkey.transports)}
+                      </Box>
+                      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: 'wrap', rowGap: 0.5 }}>
+                          <Typography variant="subtitle1" sx={{ fontWeight: 700, wordBreak: 'break-word' }}>
+                            {passkey.name}
+                          </Typography>
+                          {passkey.backedUp && <Chip size="small" color="success" icon={<CloudDoneIcon />} label="Synced" sx={{ height: 22 }} />}
+                          {passkey.deviceType === 'singleDevice' && <Chip size="small" variant="outlined" label="This device only" sx={{ height: 22 }} />}
+                        </Stack>
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                          Added {formatDate(passkey.createdAt)} · {formatLastUsed(passkey.lastUsedAt)}
+                        </Typography>
+                      </Box>
+                      <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+                        <Tooltip title="Rename">
+                          <IconButton onClick={() => openRename(passkey)} aria-label={`Rename ${passkey.name}`}>
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete">
+                          <IconButton color="error" onClick={() => setDeleteTarget(passkey)} aria-label={`Delete ${passkey.name}`}>
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
+                      </Stack>
+                    </Stack>
+                  </Paper>
+                ))}
+              </Stack>
+            )}
+          </Grid>
+
+          <Grid item xs={12} md={4}>
+            <Paper
+              sx={{
+                p: { xs: 3, md: 3.5 },
+                background: 'linear-gradient(135deg, rgba(31, 122, 99, 0.08), rgba(242, 179, 90, 0.12))',
+              }}
+            >
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 2 }}>
+                Why passkeys?
+              </Typography>
+              <Stack spacing={2}>
+                <InfoRow icon={<BoltIcon />} title="Faster sign-in" body="Skip passwords entirely — authenticate with a touch or glance." />
+                <InfoRow icon={<ShieldIcon />} title="Phishing-resistant" body="Bound to this site, so they can't be stolen or reused elsewhere." />
+                <InfoRow icon={<PhonelinkLockIcon />} title="On every device" body="Register a passkey per device, or sync them through your platform." />
+              </Stack>
+              <Divider sx={{ my: 2.5 }} />
+              <Typography variant="caption" color="text.secondary">
+                Your password still works. Passkeys are an additional, optional way to sign in and can be removed at any time.
+              </Typography>
+            </Paper>
+          </Grid>
+        </Grid>
+      </Container>
+
+      {/* Rename dialog */}
+      <Dialog open={Boolean(renameTarget)} onClose={() => !renaming && setRenameTarget(null)} maxWidth="xs" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700 }}>Rename passkey</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ mb: 2 }}>Give this passkey a name you&apos;ll recognise, like “Work laptop” or “iPhone”.</DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            label="Passkey name"
+            value={renameValue}
+            onChange={e => setRenameValue(e.target.value)}
+            inputProps={{ maxLength: 60 }}
+            onKeyDown={e => e.key === 'Enter' && submitRename()}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setRenameTarget(null)} disabled={renaming} sx={{ color: 'text.secondary' }}>
+            Cancel
+          </Button>
+          <Button variant="contained" onClick={submitRename} disabled={renaming || !renameValue.trim()}>
+            {renaming ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={Boolean(deleteTarget)} onClose={() => !deleting && setDeleteTarget(null)} maxWidth="xs" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700 }}>Remove this passkey?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            “{deleteTarget?.name}” will no longer be able to sign in to your account. This can&apos;t be undone, but you can always add a new passkey later.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDeleteTarget(null)} disabled={deleting} sx={{ color: 'text.secondary' }}>
+            Cancel
+          </Button>
+          <Button variant="contained" color="error" onClick={confirmDelete} disabled={deleting}>
+            {deleting ? 'Removing…' : 'Remove passkey'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={snack.open} autoHideDuration={4000} onClose={closeSnack} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        <Alert onClose={closeSnack} severity={snack.severity} variant="filled" sx={{ width: '100%' }}>
+          {snack.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}
+
+function InfoRow({ icon, title, body }) {
+  return (
+    <Stack direction="row" spacing={1.5} alignItems="flex-start">
+      <Box sx={{ color: 'primary.main', mt: 0.25 }}>{icon}</Box>
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+          {title}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {body}
+        </Typography>
+      </Box>
+    </Stack>
+  );
+}
+
+export default Passkeys;

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -3,6 +3,9 @@ import { Container, TextField, Button, Typography, Paper, Box, Grid, Divider } f
 import api from '../services/api';
 import { useNavigate, Link } from 'react-router-dom';
 import LoadingOverlay from '../components/LoadingOverlay';
+import { setToken } from '../services/auth';
+import { isPasskeySupported } from '../services/passkeys';
+import PasskeyPromptModal from '../components/PasskeyPromptModal';
 
 function Register() {
   const [username, setUsername] = useState('');
@@ -12,6 +15,7 @@ function Register() {
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [showPasskeyModal, setShowPasskeyModal] = useState(false);
   const navigate = useNavigate();
 
   const handleRegister = async () => {
@@ -22,12 +26,23 @@ function Register() {
     }
     setLoading(true);
     try {
-      await api.post('/api/auth/register', { username, email, password });
+      const res = await api.post('/api/auth/register', { username, email, password });
       setSuccess(true);
       setError(null);
-      setTimeout(() => {
-        navigate('/login');
-      }, 1500);
+
+      // The API auto-logs-in on registration. If we have a session and the
+      // browser supports passkeys, invite the user to enrol one right away;
+      // otherwise head straight into the app.
+      if (res.data?.token) {
+        setToken(res.data.token);
+        if (isPasskeySupported()) {
+          setShowPasskeyModal(true);
+        } else {
+          setTimeout(() => navigate('/budgets'), 1200);
+        }
+      } else {
+        setTimeout(() => navigate('/login'), 1500);
+      }
     } catch (err) {
       console.error(err);
       setError('Registration failed. Maybe email is already in use, or an error has occurred.');
@@ -36,9 +51,16 @@ function Register() {
     }
   };
 
+  const handlePasskeyModalClose = created => {
+    setShowPasskeyModal(false);
+    navigate(created ? '/passkeys' : '/budgets');
+  };
+
   return (
     <Box sx={{ py: { xs: 4, md: 8 } }}>
       <LoadingOverlay loading={loading} />
+      <PasskeyPromptModal open={showPasskeyModal} onClose={handlePasskeyModalClose} />
+
       <Container>
         <Grid container spacing={4} alignItems="center" justifyContent="center">
           <Grid item xs={12} md={6}>
@@ -56,7 +78,7 @@ function Register() {
               )}
               {success && (
                 <Typography color="primary" mb={2}>
-                  Registration successful. Redirecting...
+                  Account created successfully.
                 </Typography>
               )}
               <TextField

--- a/frontend/src/services/passkeys.js
+++ b/frontend/src/services/passkeys.js
@@ -1,0 +1,99 @@
+// Thin client wrapper around the passkey (WebAuthn) endpoints. It orchestrates
+// the two-step ceremonies — fetch options from the server, hand them to the
+// authenticator via @simplewebauthn/browser, then post the result back for
+// verification — and normalises authenticator errors into friendly messages.
+
+import {
+  startRegistration,
+  startAuthentication,
+  browserSupportsWebAuthn,
+  browserSupportsWebAuthnAutofill,
+  platformAuthenticatorIsAvailable,
+  WebAuthnError,
+} from '@simplewebauthn/browser';
+import api from './api';
+
+export const isPasskeySupported = () => browserSupportsWebAuthn();
+
+export const isPlatformAuthenticatorAvailable = async () => {
+  try {
+    return await platformAuthenticatorIsAvailable();
+  } catch {
+    return false;
+  }
+};
+
+export const isConditionalMediationAvailable = async () => {
+  try {
+    return await browserSupportsWebAuthnAutofill();
+  } catch {
+    return false;
+  }
+};
+
+// Translate the grab-bag of DOMException / WebAuthnError codes into copy a
+// human can act on. Cancellations are flagged so callers can stay silent.
+export const describePasskeyError = err => {
+  const name = err?.name || err?.code;
+  if (err instanceof WebAuthnError || name) {
+    switch (name) {
+      case 'NotAllowedError':
+        return { cancelled: true, message: 'Passkey prompt was dismissed or timed out.' };
+      case 'InvalidStateError':
+        return { cancelled: false, message: 'This device already has a passkey for your account.' };
+      case 'AbortError':
+        return { cancelled: true, message: 'Passkey request was cancelled.' };
+      case 'SecurityError':
+        return { cancelled: false, message: 'This site is not allowed to use passkeys (check the domain/HTTPS).' };
+      case 'NotSupportedError':
+        return { cancelled: false, message: 'This authenticator is not supported.' };
+      default:
+        break;
+    }
+  }
+  const apiMessage = err?.response?.data?.error;
+  return { cancelled: false, message: apiMessage || err?.message || 'Something went wrong with the passkey.' };
+};
+
+/**
+ * Run the registration ceremony for the currently authenticated user.
+ * @param {string} [name] Optional friendly label.
+ * @returns the stored passkey metadata.
+ */
+export const registerPasskey = async name => {
+  const { data: options } = await api.post('/api/passkeys/register/options');
+  const attestationResponse = await startRegistration({ optionsJSON: options });
+  const { data } = await api.post('/api/passkeys/register/verify', {
+    response: attestationResponse,
+    name,
+  });
+  return data.passkey;
+};
+
+/**
+ * Run the passwordless authentication ceremony.
+ * @returns {Promise<string>} a JWT for the authenticated session.
+ */
+export const authenticateWithPasskey = async () => {
+  const { data } = await api.post('/api/passkeys/login/options');
+  const assertionResponse = await startAuthentication({ optionsJSON: data.options });
+  const { data: result } = await api.post('/api/passkeys/login/verify', {
+    flowId: data.flowId,
+    response: assertionResponse,
+  });
+  return result.token;
+};
+
+export const listPasskeys = async () => {
+  const { data } = await api.get('/api/passkeys');
+  return data;
+};
+
+export const renamePasskey = async (id, name) => {
+  const { data } = await api.patch(`/api/passkeys/${id}`, { name });
+  return data;
+};
+
+export const deletePasskey = async id => {
+  await api.delete(`/api/passkeys/${id}`);
+};

--- a/models/passkey.js
+++ b/models/passkey.js
@@ -1,0 +1,123 @@
+const mongoose = require('mongoose');
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Passkey:
+ *       type: object
+ *       properties:
+ *         _id:
+ *           type: string
+ *           description: The auto-generated ID of the passkey record.
+ *           example: "64c9f8f2a73c2f001b3c68f4"
+ *         name:
+ *           type: string
+ *           description: A user-friendly label for the passkey.
+ *           example: "MacBook Touch ID"
+ *         deviceType:
+ *           type: string
+ *           description: Whether the credential lives on a single device or is synced.
+ *           enum: [singleDevice, multiDevice]
+ *           example: "multiDevice"
+ *         backedUp:
+ *           type: boolean
+ *           description: Whether the credential is backed up / synced (e.g. via iCloud Keychain).
+ *           example: true
+ *         transports:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: The transports the authenticator advertised.
+ *           example: ["internal", "hybrid"]
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           example: "2024-10-01T12:34:56.789Z"
+ *         lastUsedAt:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *           example: "2024-10-05T08:11:02.000Z"
+ */
+
+/**
+ * A single WebAuthn credential (passkey) belonging to a user. A user may own
+ * many passkeys. The public key, signature counter and credential id are the
+ * security-critical fields; everything else is metadata for the management UI.
+ */
+const passkeySchema = new mongoose.Schema(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    // Base64URL-encoded credential ID. Unique across all users.
+    credentialID: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    // COSE public key bytes returned by the authenticator.
+    publicKey: {
+      type: Buffer,
+      required: true,
+    },
+    // Signature counter used to detect cloned authenticators.
+    counter: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    transports: {
+      type: [String],
+      default: [],
+    },
+    // 'singleDevice' | 'multiDevice' (synced passkey).
+    deviceType: {
+      type: String,
+      enum: ['singleDevice', 'multiDevice'],
+      default: 'singleDevice',
+    },
+    backedUp: {
+      type: Boolean,
+      default: false,
+    },
+    // Authenticator model identifier; used to suggest a friendly name.
+    aaguid: {
+      type: String,
+      default: '',
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      maxlength: 60,
+    },
+    lastUsedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: { createdAt: 'createdAt', updatedAt: 'updatedAt' } }
+);
+
+// Expose a lean, credential-free view for API responses. The public key,
+// counter and raw credential id never need to leave the server.
+passkeySchema.methods.toClientJSON = function () {
+  return {
+    id: this._id.toString(),
+    name: this.name,
+    deviceType: this.deviceType,
+    backedUp: this.backedUp,
+    transports: this.transports,
+    aaguid: this.aaguid,
+    createdAt: this.createdAt,
+    lastUsedAt: this.lastUsedAt,
+  };
+};
+
+module.exports = mongoose.model('Passkey', passkeySchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@faker-js/faker": "^9.3.0",
         "@grpc/grpc-js": "^1.12.5",
         "@grpc/proto-loader": "^0.7.13",
+        "@simplewebauthn/server": "^13.3.1",
         "amqplib": "^0.10.4",
         "axios": "^1.7.2",
         "bcrypt": "^5.1.1",
@@ -718,6 +719,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1194,6 +1201,12 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
@@ -1283,6 +1296,174 @@
       "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1399,6 +1580,25 @@
       "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
       "peerDependencies": {
         "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.1.tgz",
+      "integrity": "sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1764,6 +1964,20 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -6507,6 +6721,24 @@
         }
       ]
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -6601,6 +6833,12 @@
         "@redis/search": "1.1.6",
         "@redis/time-series": "1.0.5"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7471,6 +7709,30 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type": {
       "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@faker-js/faker": "^9.3.0",
     "@grpc/grpc-js": "^1.12.5",
     "@grpc/proto-loader": "^0.7.13",
+    "@simplewebauthn/server": "^13.3.1",
     "amqplib": "^0.10.4",
     "axios": "^1.7.2",
     "bcrypt": "^5.1.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,6 +11,7 @@ const notificationRoutes = require('./notificationRoutes');
 const searchRoutes = require('./searchRoutes');
 const transactionRoutes = require('./transactionRoutes');
 const healthRoutes = require('./healthRoutes');
+const passkeyRoutes = require('./passkeyRoutes');
 
 const router = express.Router();
 
@@ -18,6 +19,7 @@ router.use('/orders', orderRoutes);
 router.use('/customers', customerRoutes);
 router.use('/tasks', taskRoutes);
 router.use('/auth', authRoutes);
+router.use('/passkeys', passkeyRoutes);
 router.use('/users', userRoutes);
 router.use('/budgets', budgetRoutes);
 router.use('/expenses', expenseRoutes);

--- a/routes/passkeyRoutes.js
+++ b/routes/passkeyRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const {
+  getRegistrationOptions,
+  verifyRegistration,
+  getLoginOptions,
+  verifyLogin,
+  listPasskeys,
+  renamePasskey,
+  deletePasskey,
+} = require('../controllers/passkeyController');
+const authenticate = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+// Passwordless login ceremony — public, no JWT required.
+router.post('/login/options', getLoginOptions);
+router.post('/login/verify', verifyLogin);
+
+// Registration + management — require an authenticated session.
+router.post('/register/options', authenticate, getRegistrationOptions);
+router.post('/register/verify', authenticate, verifyRegistration);
+router.get('/', authenticate, listPasskeys);
+router.patch('/:id', authenticate, renamePasskey);
+router.delete('/:id', authenticate, deletePasskey);
+
+module.exports = router;

--- a/services/passkeyMetadata.js
+++ b/services/passkeyMetadata.js
@@ -1,0 +1,52 @@
+/**
+ * Maps well-known authenticator AAGUIDs to human-friendly names and derives a
+ * sensible default label for a freshly registered passkey. The list mirrors the
+ * community-maintained passkey provider AAGUID dataset; unknown authenticators
+ * fall back to a transport/device-type heuristic.
+ */
+
+const AAGUID_NAMES = {
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4': 'Google Password Manager',
+  'adce0002-35bc-c60a-648b-0b25f1f05503': 'Chrome on Mac',
+  '08987058-cadc-4b81-b6e1-30de50dcbe96': 'Windows Hello',
+  '9ddd1817-af5a-4672-a2b9-3e3dd95000a9': 'Windows Hello',
+  '6028b017-b1d4-4c02-b4b3-afcdafc96bb2': 'Windows Hello',
+  'fbfc3007-154e-4ecc-8c0b-6e020557d7bd': 'iCloud Keychain',
+  'dd4ec289-e01d-41c9-bb89-70fa845d4bf2': 'iCloud Keychain (Managed)',
+  'bada5566-a7aa-401f-bd96-45619a55120d': '1Password',
+  'b84e4048-15dc-4dd0-8640-f4f60813c8af': 'NordPass',
+  '0ea242b4-43c4-4a1b-8b17-dd6d0b6baec6': 'Keeper',
+  'f3809540-7f14-49c1-a8b3-8f813b225541': 'Enpass',
+  '891494da-2c90-4d31-a9d4-4eb0676a53ec': 'Proton Pass',
+  '531126d6-e717-415c-9320-3d9aa6981239': 'Dashlane',
+  'fdb141b2-5d84-443e-8a35-4698c205a502': 'KeePassXC',
+  'd548826e-79b4-db40-a3d8-11116f7e8349': 'Bitwarden',
+  'cc45f64e-52a2-451b-831a-4edd8022a202': 'ToothPic Passkey Provider',
+  '2fc0579f-8113-47ea-b116-bb5a8db9202a': 'YubiKey 5 Series',
+  'cb69481e-8ff7-4039-93ec-0a2729a154a8': 'YubiKey 5 Series',
+  'ee882879-721c-4913-9775-3dfcce97072a': 'YubiKey 5 Series',
+  'fa2b99dc-9e39-4257-8f92-4a30d23c4118': 'YubiKey 5 Series (NFC)',
+};
+
+const ZERO_AAGUID = '00000000-0000-0000-0000-000000000000';
+
+/**
+ * Derive a friendly default name for a newly registered passkey.
+ * @param {{ aaguid?: string, transports?: string[], deviceType?: string }} info
+ * @returns {string}
+ */
+const defaultPasskeyName = ({ aaguid, transports = [], deviceType } = {}) => {
+  if (aaguid && aaguid !== ZERO_AAGUID && AAGUID_NAMES[aaguid]) {
+    return AAGUID_NAMES[aaguid];
+  }
+
+  const t = new Set(transports);
+  if (t.has('internal')) return 'This device';
+  if (t.has('hybrid')) return 'Phone or tablet';
+  if (t.has('usb') || t.has('nfc') || t.has('ble')) return 'Security key';
+  if (deviceType === 'multiDevice') return 'Synced passkey';
+
+  return 'Passkey';
+};
+
+module.exports = { AAGUID_NAMES, defaultPasskeyName };


### PR DESCRIPTION
## Summary

Integrates passkeys (WebAuthn) end-to-end alongside the existing JWT/password auth, using [`@simplewebauthn`](https://simplewebauthn.dev/) on both server and client. Users can register **multiple** passkeys, manage them on a new page, and sign in passwordlessly.

## Backend

- **`models/passkey.js`** — multiple credentials per user; `toClientJSON()` never leaks the public key, counter, or raw credential ID.
- **`controllers/passkeyController.js`** — registration, passwordless **discoverable-credential** login, list, rename, delete. Challenges are stored in Redis with a 5-minute, single-use TTL.
- **`config/webauthn.js`** — resolves `rpID`/origin per request (works on `localhost` in dev); optional `WEBAUTHN_ORIGINS` allowlist returns **403** for unlisted origins.
- **`services/passkeyMetadata.js`** — friendly default credential names from AAGUID/transports (e.g. "iCloud Keychain", "Security key").
- **`POST /api/auth/register`** now auto-logs-in (returns a JWT) so the post-signup passkey prompt can run. New routes mounted under `/api/passkeys/*` (login endpoints public; management endpoints behind the existing `authMiddleware`). Swagger docs included.

## Frontend

- **`services/passkeys.js`** — wraps the two-step ceremonies with normalized error handling (user cancellations stay silent).
- **`pages/Passkeys.js`** — styled management page (add / rename / delete) with custom confirmation dialogs + snackbars (no native `alert`/`prompt`), an empty state, and a "why passkeys" info panel. Protected route at `/passkeys`.
- **`components/PasskeyPromptModal.js`** — custom post-signup modal inviting passkey enrolment.
- **`pages/Login.js`** — "Sign in with a passkey" button.
- **`components/Navbar.js`** — the lone Log Out button is replaced (when signed in) by an **Account** dropdown → **Passkeys** + destructive (red) **Log Out**, on both desktop and the mobile drawer.

## Production config

Set on the backend so passkeys bind to your real domain (left blank, they derive from the request origin — fine for local dev). Redis must be available, since challenges depend on it.

```
RP_ID=yourdomain.com
RP_NAME=Budget Management System
WEBAUTHN_ORIGINS=https://yourfrontend.com
```

## Test plan

- [x] Backend integration test (real router + middleware, Redis/Mongo stubbed): public login options, 401 guards on protected routes, live option generation, Redis challenge storage, origin-allowlist 403, input validation — 14/14.
- [x] Frontend compiles clean under `CI=true react-scripts build` (zero lint warnings).
- [x] Swagger spec generates all 6 passkey paths + schema.
- [ ] **Manual (needs a real browser + authenticator against a running stack):** sign up → passkey modal → create a passkey.
- [ ] Log out, then "Sign in with a passkey".
- [ ] On `/passkeys`: add a second passkey, rename it, delete it.
- [ ] Account dropdown renders correctly on desktop and in the mobile drawer.

> Note: a full live WebAuthn ceremony couldn't be exercised in the build environment (no local Mongo/Redis; the frontend targets the production API). The pre-existing `decoded.id` blacklist quirk in `authMiddleware` was left untouched (out of scope).

https://claude.ai/code/session_01KzWjuPnYC6jtfJZ3acXogD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzWjuPnYC6jtfJZ3acXogD)_