### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/apache-kafka/docker/docker-compose.yml
+++ b/apache-kafka/docker/docker-compose.yml
@@ -2,15 +2,15 @@ version: '3.8'
 
 services:
   zookeeper:
-    image: bitnami/zookeeper:3
+    image: soldevelo/zookeeper:3.9
     container_name: kafka_zookeeper
     ports:
       - "2181:2181"
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      - ALLOW_EMPTY_PASSWORD=yes
 
   kafka:
-    image: bitnami/kafka:3
+    image: soldevelo/kafka:3.9
     container_name: kafka_broker
     ports:
       - "9092:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       RABBITMQ_DEFAULT_PASS: guest
 
   kafka:
-    image: bitnami/kafka:3
+    image: soldevelo/kafka:3.9
     container_name: kafka
     ports:
       - "9092:9092"
@@ -60,10 +60,12 @@ services:
       - zookeeper
 
   zookeeper:
-    image: bitnami/zookeeper:3
+    image: soldevelo/zookeeper:3.9
     container_name: zookeeper
     ports:
       - "2181:2181"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
 
 volumes:
   mongo-data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       RABBITMQ_DEFAULT_PASS: guest
 
   kafka:
-    image: bitnami/kafka:3
+    image: soldevelo/kafka:3.9
     container_name: kafka
     ports:
       - "9092:9092"
@@ -60,10 +60,12 @@ services:
       - zookeeper
 
   zookeeper:
-    image: bitnami/zookeeper:3
+    image: soldevelo/zookeeper:3.9
     container_name: zookeeper
     ports:
       - "2181:2181"
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
 
 volumes:
   mongo-data:

--- a/kubernetes/docker/Dockerfile
+++ b/kubernetes/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.30
+FROM alpine/k8s:1.30.14
 
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/kafka:3` → [`soldevelo/kafka:3.9`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/zookeeper:3` → [`soldevelo/zookeeper:3.9`](https://hub.docker.com/r/soldevelo/zookeeper)

> `zookeeper:3.9` requires `ALLOW_EMPTY_PASSWORD=yes` instead of `ALLOW_ANONYMOUS_LOGIN=yes` for unauthenticated dev setups. All compose files updated accordingly.